### PR TITLE
Swap deactivate "destroy" method with "cancel"

### DIFF
--- a/lib/php-checkstyle.coffee
+++ b/lib/php-checkstyle.coffee
@@ -19,8 +19,7 @@ module.exports =
     @phpCheckstyleView = new PhpCheckstyleView(state.phpCheckstyleViewState)
     @phpCsFixerView = new PhpCsFixerView(state.phpCsFixerView)
 
-  deactivate: ->
-    @phpCheckstyleView.destroy()
+  deactivate: -> @phpCheckstyleView.cancel()
 
   serialize: ->
     phpCheckstyleViewState: @phpCheckstyleView.serialize()


### PR DESCRIPTION
When updating I got an exception in the console:

```
Uncaught TypeError: Object #<PhpCheckstyleView> has no method 'destroy' php-checkstyle.coffee:23
module.exports.deactivate php-checkstyle.coffee:23
module.exports.Package.deactivate /Applications/Atom.app/Contents/Resources/app/src/package.js:383
module.exports.PackageManager.deactivatePackage /Applications/Atom.app/Contents/Resources/app/src/package-manager.js:128
module.exports.PackageManager.update /Applications/Atom.app/Contents/Resources/app/node_modules/settings-view/lib/package-manager.js:136
module.exports.InstalledPackageView.installUpdate /Applications/Atom.app/Contents/Resources/app/node_modules/settings-view/lib/installed-package-view…:254
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/settings-view/lib/installed-package-view…:281
jQuery.event.dispatch /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4676
elemData.handle /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4360
```

Destroy wasn't defined, looks like `cancel()` is defined in the View parent class though.
