### PR TITLE
Don't show error list when there are no errors

### DIFF
--- a/lib/php-checkstyle-view.coffee
+++ b/lib/php-checkstyle-view.coffee
@@ -38,6 +38,9 @@ class PhpCheckstyleView extends PhpCheckstyleBaseView
     @checkstyleList[editorView.id] = fileList
     @renderGutter()
     @setItems(fileList)
+    
+    return unless fileList.length > 0
+    
     @storeFocusedElement()
     atom.workspaceView.append(this)
     @focusFilterEditor()


### PR DESCRIPTION
Little annoying to have it popup on every save, even when the file is clean. This prevents it from displaying the list, after clearing the items and gutter classes.
