### PR TITLE
Escape spaces and apostrophes in filepaths.

### DIFF
--- a/lib/php-checkstyle.coffee
+++ b/lib/php-checkstyle.coffee
@@ -36,7 +36,7 @@ class PhpCheckstyle
       return
 
     shellCommands = []
-    
+
     editorPath = editor.getPath().replace(/([\'\s])/g, "\\$1")
 
     if atom.config.get("php-checkstyle.shouldExecuteLinter") is true
@@ -58,7 +58,7 @@ class PhpCheckstyle
         'executablePath': atom.config.get("php-checkstyle.phpmdExecutablePath"),
         'ruleSets': atom.config.get("php-checkstyle.phpmdRuleSets")
       })
-      shellCommands.push(messDetector)g
+      shellCommands.push(messDetector)
 
     shell = new commands.Shell(shellCommands)
 
@@ -94,7 +94,7 @@ class PhpCheckstyle
       'executablePath': executablePath,
       'level': level
     }
-    
+
     editorPath = editor.getPath().replace(/([\'\s])/g, "\\$1")
 
     fixer = new commands.CommandPhpcsFixer(editorPath, config)

--- a/lib/php-checkstyle.coffee
+++ b/lib/php-checkstyle.coffee
@@ -36,15 +36,17 @@ class PhpCheckstyle
       return
 
     shellCommands = []
+    
+    editorPath = editor.getPath().replace(/([\'\s])/g, "\\$1")
 
     if atom.config.get("php-checkstyle.shouldExecuteLinter") is true
-      linter = new commands.CommandLinter(editor.getPath(), {
+      linter = new commands.CommandLinter(editorPath, {
         'executablePath': atom.config.get "php-checkstyle.phpPath"
       })
       shellCommands.push(linter)
 
     if atom.config.get("php-checkstyle.shouldExecutePhpcs") is true
-      phpcs = new commands.CommandPhpcs(editor.getPath(), {
+      phpcs = new commands.CommandPhpcs(editorPath, {
         'executablePath': atom.config.get("php-checkstyle.phpcsExecutablePath"),
         'standard': atom.config.get("php-checkstyle.phpcsStandard"),
         'warnings': atom.config.get("php-checkstyle.phpcsDisplayWarnings")
@@ -52,11 +54,11 @@ class PhpCheckstyle
       shellCommands.push(phpcs)
 
     if atom.config.get("php-checkstyle.shouldExecutePhpmd") is true
-      messDetector= new commands.CommandMessDetector(editor.getPath(), {
+      messDetector= new commands.CommandMessDetector(editorPath, {
         'executablePath': atom.config.get("php-checkstyle.phpmdExecutablePath"),
         'ruleSets': atom.config.get("php-checkstyle.phpmdRuleSets")
       })
-      shellCommands.push(messDetector)
+      shellCommands.push(messDetector)g
 
     shell = new commands.Shell(shellCommands)
 
@@ -92,8 +94,10 @@ class PhpCheckstyle
       'executablePath': executablePath,
       'level': level
     }
+    
+    editorPath = editor.getPath().replace(/([\'\s])/g, "\\$1")
 
-    fixer = new commands.CommandPhpcsFixer(editor.getPath(), config)
+    fixer = new commands.CommandPhpcsFixer(editorPath, config)
     command = new commands.Shell([fixer])
 
     command.execute (err, stdout, stderr) =>


### PR DESCRIPTION
This changes `/Volumes/myname's home/my-project/test.php` to `/Volumes/myname\'s\ home/my-project/test.php` so phpcs, etc. don't break while editing files with spaces or apostrophes in their path.
