### PR TITLE
:lipstick: Add custom gutter colours per checking command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ The plugin renders the errors in the following formats, again configurable:
 * Gutter view
 * Status bar view
 
+You can customise the colours used in the gutter by providing your own stylesheet, just override the css colours for
+the 3 CSS classes:
+
+```css
+.php-checkstyle-report-phpcs
+.php-checkstyle-report-phpmd
+.php-checkstyle-report-lint
+```
+
+the defaults colours are:
+
+```css
+@background-color-phpcs: #3292B8;  
+@background-color-phpmd: #A087DE;  
+@background-color-lint: @background-color-error;
+```
+
 ## List View
 ![PHP Checkstyle List View](http://www.soulbroken.co.uk/wp-content/uploads/atom-php-checkstyle-sniffer.png)
 

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -46,7 +46,7 @@ class CommandPhpcs
     pattern = /.*line="(.+?)" column="(.+?)" severity="(.+?)" message="(.*)" source.*/g
     errorList = []
     while (line = pattern.exec(stdout)) isnt null
-      item = [line[1], _.unescape(line[4])]
+      item = [line[1], _.unescape(line[4]), 'php-checkstyle-report-phpcs']
       errorList.push item
     return errorList
 
@@ -72,7 +72,7 @@ class CommandLinter
     pattern = /(.*) on line (.*)/g
     errorList = []
     while (line = pattern.exec(stdout)) isnt null
-      item = [line[2], line[1]]
+      item = [line[2], line[1], 'php-checkstyle-report-lint']
       errorList.push item
     return errorList
 
@@ -98,7 +98,7 @@ class CommandMessDetector
     pattern = /.*:(\d+)[ \t]+(.*)/g
     errorList = []
     while (line = pattern.exec(stdout)) isnt null
-      item = [line[1], _.unescape(line[2])]
+      item = [line[1], _.unescape(line[2]), 'php-checkstyle-report-phpmd']
       errorList.push item
     return errorList
 

--- a/lib/php-checkstyle-gutter-view.coffee
+++ b/lib/php-checkstyle-gutter-view.coffee
@@ -4,6 +4,7 @@ class PhpCheckstyleGutterView
   # Instantiation
   constructor: ->
     @checkstyleList = []
+    @gutterStyles = ['php-checkstyle-sniff-error', 'php-checkstyle-sniff-warning', 'php-checkstyle-report-phpcs', 'php-checkstyle-report-phpmd', 'php-checkstyle-report-lint']
 
   # Process the report data
   #
@@ -13,12 +14,7 @@ class PhpCheckstyleGutterView
 
     editorView = atom.workspaceView.getActiveView()
 
-    gutterList = []
-    for row in reportList
-      line = row[0]
-      gutterList.push(line)
-
-    @checkstyleList[editorView.id] = gutterList
+    @checkstyleList[editorView.id] = reportList
     @render()
 
   # Render said gutter
@@ -29,9 +25,11 @@ class PhpCheckstyleGutterView
     return unless @checkstyleList[editorView.id]
 
     gutter = editorView.gutter
-    gutter.removeClassFromAllLines('php-checkstyle-sniff-error')
+
+    for gutterStyle in @gutterStyles
+      gutter.removeClassFromAllLines(gutterStyle)
 
     for line in @checkstyleList[editorView.id]
-      gutter.addClassToLine(line - 1, 'php-checkstyle-sniff-error')
+      gutter.addClassToLine(line[0] - 1, line[2])
 
 module.exports = PhpCheckstyleGutterView

--- a/stylesheets/php-checkstyle.less
+++ b/stylesheets/php-checkstyle.less
@@ -4,8 +4,32 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
+@background-color-phpcs: #3292B8;
+@background-color-phpmd: #A087DE;
+@background-color-lint: @background-color-error;
+
 .php-checkstyle-sniff-error {
   background: @background-color-error;
+  color: #FFF !important;
+}
+
+.php-checkstyle-sniff-warning {
+  background: @background-color-warning;
+  color: #FFF !important;
+}
+
+.php-checkstyle-report-phpcs {
+  background: @background-color-phpcs;
+  color: #FFF !important;
+}
+
+.php-checkstyle-report-lint {
+  background: @background-color-lint;
+  color: #FFF !important;
+}
+
+.php-checkstyle-report-phpmd {
+  background: @background-color-phpmd;
   color: #FFF !important;
 }
 


### PR DESCRIPTION
Added custom CSS classes as suggested, which I append to each item when building the errorList. Because the classes are now needed in the gutter renderer I pass the whole array in rather than just parsing out the line number into a separate array. That was the easiest way to differentiate between different errors/warnings.

Fixes #20 
